### PR TITLE
Changed PlaceTopic.creationDate and PlaceTopic.,odificationDate from Int32 to Int64

### DIFF
--- a/Net.Pokeshot.JiveSdk/Models/Place.cs
+++ b/Net.Pokeshot.JiveSdk/Models/Place.cs
@@ -35,11 +35,11 @@ namespace Net.Pokeshot.JiveSdk.Models
 
     public class PlaceTopic
     {
-        public int creationDate { get; set; }
+        public Int64 creationDate { get; set; }
         public string displayNameLocalized { get; set; }
         public bool hidden { get; set; }
         public string id { get; set; }
-        public int modificationDate { get; set; }
+        public Int64 modificationDate { get; set; }
         public string name { get; set; }
     }
 }


### PR DESCRIPTION
I changed these variables from Int32 to Int64 as the values returned from the Jive API are greater then Int32.MaxValue. This causes the following exception to be thrown when deserializeing the response.

    System.OverflowException: Value was either too large or too small for an Int32. 